### PR TITLE
Add axes command to show cell axis directions

### DIFF
--- a/psico/xtal.py
+++ b/psico/xtal.py
@@ -363,6 +363,9 @@ DESCRIPTION
 
     Draw arrows corresponding to the crystallographic axes.
 
+    The default color palette is colorblind friendly but close to the familiar red, green, and blue for the a, b, and, c axes respectively.
+    (See https://colorbrewer2.org/#type=qualitative&scheme=Dark2&n=3 for details)
+
 USAGE
 
     cell_axes [ object, [, a_color [, b_color [, c_color, [ name]]]]

--- a/psico/xtal.py
+++ b/psico/xtal.py
@@ -7,6 +7,7 @@ License: BSD-2-Clause
 '''
 
 from pymol import cmd, CmdException
+from chempy import cpv
 
 def cellbasis(angles, edges):
     '''
@@ -316,7 +317,6 @@ EXAMPLE
     cmd.disable(name)
     cmd.group('%s_%s' % (prefix, suffix), '%s_%s_*' % (prefix, suffix))
 
-from chempy import cpv
 
 class PutCenterCallback(object):
     prev_v = None
@@ -363,7 +363,8 @@ DESCRIPTION
 
     Draw arrows corresponding to the crystallographic axes.
 
-    The default color palette is colorblind friendly but close to the familiar red, green, and blue for the a, b, and, c axes respectively.
+    The default color palette is colorblind friendly but close to the familiar 
+    red, green, and blue for the a, b, and, c axes respectively.
     (See https://colorbrewer2.org/#type=qualitative&scheme=Dark2&n=3 for details)
 
 USAGE
@@ -442,3 +443,4 @@ cmd.auto_arg[0]['biomolecule'] = cmd.auto_arg[0]['pseudoatom']
 cmd.auto_arg[3]['supercell'] = cmd.auto_arg[0]['pseudoatom']
 cmd.auto_arg[0]["cell_axes"] = [cmd.object_sc, "object", ""]
 
+# vi: ts=4:sw=4:smarttab:expandtab

--- a/psico/xtal.py
+++ b/psico/xtal.py
@@ -319,10 +319,6 @@ EXAMPLE
 from chempy import cpv
 
 class PutCenterCallback(object):
-    """
-    This class will keep a CGO object located in the bottom left. 
-    Source: https://pymolwiki.org/index.php/Axes
-    """
     prev_v = None
 
     def __init__(self, name, corner=0):
@@ -368,7 +364,6 @@ def axes(name='axes', object=None):
 DESCRIPTION
 
     Puts coordinate axes to the lower left corner of the viewport.
-    The angles of the axes correspond to the crystallographic basis vectors. 
     '''
     from pymol import cgo
 

--- a/psico/xtal.py
+++ b/psico/xtal.py
@@ -319,6 +319,10 @@ EXAMPLE
 from chempy import cpv
 
 class PutCenterCallback(object):
+    """
+    This class will keep a CGO object located in the bottom left. 
+    Source: https://pymolwiki.org/index.php/Axes
+    """
     prev_v = None
 
     def __init__(self, name, corner=0):
@@ -364,6 +368,7 @@ def axes(name='axes', object=None):
 DESCRIPTION
 
     Puts coordinate axes to the lower left corner of the viewport.
+    The angles of the axes correspond to the crystallographic basis vectors. 
     '''
     from pymol import cgo
 

--- a/psico/xtal.py
+++ b/psico/xtal.py
@@ -357,13 +357,28 @@ class PutCenterCallback(object):
         m = [z, 0, 0, 0, 0, z, 0, 0, 0, 0, z, 0, t[0] / z, t[1] / z, t[2] / z, 1]
         cmd.set_object_ttt(self.name, m)
 
-
-
-def axes(name='axes', object=None):
+def cell_axes(object=None, a_color='0xd95f02', b_color='0x1b9e77', c_color='0x7570b3', name='cell_axes'):
     '''
 DESCRIPTION
 
-    Puts coordinate axes to the lower left corner of the viewport.
+    Draw arrows corresponding to the crystallographic axes.
+
+USAGE
+
+    cell_axes [ object, [, a_color [, b_color [, c_color, [ name]]]]
+
+ARGUMENTS
+
+    object = string: name of object to take cell definition from
+
+    a_color = string: color of a-axis {default: '0xd95f02'}
+
+    b_color = string: color of b-axis {default: '0x1b9e77'}
+
+    c_color = string: color of c-axis {default: '0x7570b3'}
+
+    name = string: name of the cgo object to create {default: cell_axes}
+
     '''
     from pymol import cgo
 
@@ -390,21 +405,21 @@ DESCRIPTION
 
     A,B,C = basis[:3,:3].T
     r = A / np.linalg.norm(A) 
-    rgb = [1., 0., 0.]
+    rgb = cmd.get_color_tuple(a_color)
     obj.extend([
         cgo.CYLINDER, 0.0, 0.0, 0.0, l*r[0], l*r[1], l*r[2], w, *rgb, *rgb,
         cgo.CONE, l*r[0], l*r[1], l*r[2], (h+l)*r[0], (h+l)*r[1], (h+l)*r[2], d, 0.0, *rgb, *rgb, 1.0, 1.0
     ])
 
     r = B / np.linalg.norm(B) 
-    rgb = [0., 1., 0.]
+    rgb = cmd.get_color_tuple(b_color)
     obj.extend([
         cgo.CYLINDER, 0.0, 0.0, 0.0, l*r[0], l*r[1], l*r[2], w, *rgb, *rgb,
         cgo.CONE, l*r[0], l*r[1], l*r[2], (h+l)*r[0], (h+l)*r[1], (h+l)*r[2], d, 0.0, *rgb, *rgb, 1.0, 1.0
     ])
 
     r = C / np.linalg.norm(C) 
-    rgb = [0., 0., 1.]
+    rgb = cmd.get_color_tuple(c_color)
     obj.extend([
         cgo.CYLINDER, 0.0, 0.0, 0.0, l*r[0], l*r[1], l*r[2], w, *rgb, *rgb,
         cgo.CONE, l*r[0], l*r[1], l*r[2], (h+l)*r[0], (h+l)*r[1], (h+l)*r[2], d, 0.0, *rgb, *rgb, 1.0, 1.0
@@ -413,7 +428,7 @@ DESCRIPTION
     PutCenterCallback(name, 1).load()
     cmd.load_cgo(obj, name)
 
-cmd.extend('axes', axes)
+cmd.extend('cell_axes', cell_axes)
 cmd.extend('supercell', supercell)
 cmd.extend('symexpcell', symexpcell)
 cmd.extend('biomolecule', biomolecule)
@@ -422,4 +437,3 @@ cmd.extend('biomolecule', biomolecule)
 cmd.auto_arg[0]['biomolecule'] = cmd.auto_arg[0]['pseudoatom']
 cmd.auto_arg[3]['supercell'] = cmd.auto_arg[0]['pseudoatom']
 
-# vi: ts=4:sw=4:smarttab:expandtab


### PR DESCRIPTION
This pr resolves #9 by adding an axes command that shows the directions of the cell axes A, B, C in red, green, and blue arrows.