### PR TITLE
Add `prefix` argument to `supercell` docstring

### DIFF
--- a/psico/xtal.py
+++ b/psico/xtal.py
@@ -40,7 +40,7 @@ DESCRIPTION
 
 USAGE
 
-    supercell a, b, c [, object [, color [, name [, withmates]]]]
+    supercell a, b, c [, object [, color [, name [, withmates [, prefix]]]]]
 
 ARGUMENTS
 
@@ -55,6 +55,8 @@ ARGUMENTS
 
     withmates = bool: also create symmetry mates in displayed cells
     {default: 1}
+    
+    prefix = string: prefix for names of symmetry mates {default: m}
 
 SEE ALSO
 


### PR DESCRIPTION
The `supercell` function already takes a `prefix` argument, but I realized that it is missing from the docstring. This means that from within PyMOL, users don't realize that this parameter can be changed!

The ability to change prefixes is especially important because otherwise, running `supercell` a second time in the same PyMOL session will overwrite the previous symmetry mates `m001_1`, `m001_2`, etc.