### PR TITLE
Fix CI for PyMOL 2.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/psico/aggrescanning.py
+++ b/psico/aggrescanning.py
@@ -221,7 +221,7 @@ ARGUMENTS
         }.get(key, 5)
 
     ids_key = "(model, segi, chain), resi, oneletter"
-    ids_all = iterate_to_list(f"({selection}) & guide", ids_key)
+    ids_all = iterate_to_list(f"({selection}) & guide", ids_key, _self=_self)
     data = {}
 
     def gen_chain_ranges():

--- a/psico/querying.py
+++ b/psico/querying.py
@@ -7,7 +7,8 @@ License: BSD-2-Clause
 
 from pymol import cmd, CmdException
 from pymol import selector
-from pymol.constants import CURRENT_STATE
+
+CURRENT_STATE = -1  # pymol.constants.CURRENT_STATE
 
 
 def centerofmass(selection='(all)', state=-1, quiet=1, *, _self=cmd):
@@ -501,6 +502,7 @@ def shortest_distance(selection1: str,
                       _self=cmd):
     '''
 DESCRIPTION
+
     Finds the shortest pairwise distance between two selections.
 
 ARGUMENTS
@@ -516,6 +518,11 @@ ARGUMENTS
     name = string: name of the object to create {default: shortest}
 
     quiet = 0 or 1: print results to the terminal {default: 1}
+
+EXAMPLE
+
+    fetch 2xwu
+    shortest_distance chain A, chain B
     '''
     from math import sqrt
     from chempy import cpv


### PR DESCRIPTION
- Hard-code `CURRENT_STATE` because `pymol.constants.CURRENT_STATE` is only available in PyMOL 2.4
- https://github.com/speleo3/pymol-psico/issues/18