### PR TITLE
Fix typo.

### DIFF
--- a/psico/orientation.py
+++ b/psico/orientation.py
@@ -380,9 +380,9 @@ USAGE
 
 ARGUMENTS
 
-    selection1 = string: atom selection of first helix
+    selection1 = string: atom selection of first domain
 
-    selection2 = string: atom selection of second helix
+    selection2 = string: atom selection of second domain
 
     method = string: alignment command like "align" or "super" {default: align}
 


### PR DESCRIPTION
The `angle_between_domains` docstring explicitly states not to use it for helices, so the arguments need to say `domain` instead of `helix`.